### PR TITLE
QSP 6 - FlightDelay audit fixes

### DIFF
--- a/contracts/FlightDelayRiskModule.sol
+++ b/contracts/FlightDelayRiskModule.sol
@@ -92,6 +92,10 @@ contract FlightDelayRiskModule is RiskModule, ChainlinkClientUpgradeable {
     address linkToken_,
     OracleParams memory oracleParams_
   ) internal onlyInitializing {
+    require(
+      linkToken_ != address(0),
+      "FlightDelayRiskModule: linkToken cannot be the zero address"
+    );
     setChainlinkToken(linkToken_);
     _oracleParams = oracleParams_;
   }
@@ -111,6 +115,10 @@ contract FlightDelayRiskModule is RiskModule, ChainlinkClientUpgradeable {
     external
     onlyComponentRole(ORACLE_ADMIN_ROLE)
   {
+    require(
+      newParams.oracle != address(0),
+      "FlightDelayRiskModule: oracle cannot be the zero address"
+    );
     _oracleParams = newParams;
     emit NewOracleParams(_oracleParams);
   }
@@ -141,6 +149,7 @@ contract FlightDelayRiskModule is RiskModule, ChainlinkClientUpgradeable {
     address onBehalfOf,
     uint96 internalId
   ) external onlyComponentRole(PRICER_ROLE) returns (uint256) {
+    require(bytes(flight).length > 0, "FlightDelayRiskModule: invalid flight");
     require(expectedArrival > block.timestamp, "expectedArrival can't be in the past");
     require(departure != 0 && expectedArrival > departure, "expectedArrival <= departure!");
     uint40 expiration = expectedArrival +

--- a/test/test-flight-delay-risk-module.js
+++ b/test/test-flight-delay-risk-module.js
@@ -444,7 +444,7 @@ describe("FlightDelayRiskModule contract", function () {
   }) {
     const now = await helpers.time.latest();
     const policy = {
-      flight: flight === undefined ? "AR 1234" : "",
+      flight: flight === undefined ? "AR 1234" : flight,
       departure: departure || now + 3600,
       expectedArrival: expectedArrival || now + 3600 * 5,
       tolerance: tolerance || 1800,


### PR DESCRIPTION
non-zero address validations:

- FlightDelayRiskModule.__FlightDelayRiskModule_init_unchained()
- FlightDelayRiskModule.setOracleParams()

empty string validation:
- FlightDelayRiskModule.newPolicy(): Validate that the flight number is a non empty string

